### PR TITLE
add Remux to DoVi

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -442,7 +442,7 @@ Add this to your `Preferred (3)` with a score of [15]
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?!.*(HDR|HULU))(?=.*\b(DV|Dovi|Dolby[- .]Vision)\b).*/i
+/^(?!.*(HDR|HULU|REMUX))(?=.*\b(DV|Dovi|Dolby[- .]Vision)\b).*/i
 ```
 
 #### Optional Ignore the group -scene


### PR DESCRIPTION
Add Remux into the list of sources to pull DoVi. I found these GOT examples of BluRay Remuxs in DoVi that have HDR10 Failback.

![Screen Shot 2022-01-19 at 7 33 21 PM](https://user-images.githubusercontent.com/97920769/150267439-b7b17464-7214-4131-9d6a-8a621bbbd026.png)

